### PR TITLE
Score/Rating automatically comes with requested posts without advanced mode

### DIFF
--- a/custom-requests.js
+++ b/custom-requests.js
@@ -70,7 +70,6 @@ async function afterCustomPageReceived(doc, userID, pageNum, button, listItem, l
     }
 }
 
-// TODO! Get pages from cache if available
 // handles custom page requests (based on failedPageRequestHandler)
 async function customPageRequestHandler(userID, pageNum) {
 	const list = document.getElementById('customRequestList')

--- a/favoritesSearch.html
+++ b/favoritesSearch.html
@@ -65,29 +65,6 @@
 							</ul>
 						</nav>
 					</div>
-					<div class="subUIelement" id="fileManager">
-						<h3 style="text-align: center">Import/Export Favorites</h3>
-							<div>
-								<input type="checkbox" id="removeDuplicates">
-								<label for="removeDuplicates">Remove Duplicates</label>
-								<select id="removeDuplicatesOrder">
-									<option value="first" selected>Keep First</option>
-									<option value="last">Keep Last</option>
-								</select>
-								<button type="button" id="exportFavorites">Export</button>
-							</div>
-							<div>
-								<button type="button" id="importButton" onclick="document.getElementById('importFavorites').click()">Import</button>
-								<input type="file" id="importFavorites" multiple="multiple" style="display: none;" accept=".txt, .json"></input>
-								<div class="awesomplete" id="importQueryDiv"><input id="importQuery" placeholder="Enter tags to filter imported posts" name="tags" size="23" type="text" value="" autocomplete="off" aria-autocomplete="list"><ul hidden=""></ul><span class="visually-hidden" role="status" aria-live="assertive" aria-relevant="additions"></span></div>
-								<button type="button" id= "submitImportQuery">Filter</button>
-							</div>
-						<nav id = "importedFilesNav">
-							<ul id="importedFilesList">
-
-							</ul>
-						</nav>
-					</div>
 					<fieldset id="settings" class="subUIelement">
 						<h3 style="text-align: center">Advanced Mode</h3>
 						<br>
@@ -133,6 +110,29 @@
 						</div>
 						<br>
 					</fieldset>
+					<div class="subUIelement" id="fileManager">
+						<h3 style="text-align: center">Import/Export Favorites</h3>
+							<div>
+								<input type="checkbox" id="removeDuplicates">
+								<label for="removeDuplicates">Remove Duplicates</label>
+								<select id="removeDuplicatesOrder">
+									<option value="first" selected>Keep First</option>
+									<option value="last">Keep Last</option>
+								</select>
+								<button type="button" id="exportFavorites">Export</button>
+							</div>
+							<div>
+								<button type="button" id="importButton" onclick="document.getElementById('importFavorites').click()">Import</button>
+								<input type="file" id="importFavorites" multiple="multiple" style="display: none;" accept=".txt, .json"></input>
+								<div class="awesomplete" id="importQueryDiv"><input id="importQuery" placeholder="Enter tags to filter imported posts" name="tags" size="23" type="text" value="" autocomplete="off" aria-autocomplete="list"><ul hidden=""></ul><span class="visually-hidden" role="status" aria-live="assertive" aria-relevant="additions"></span></div>
+								<button type="button" id= "submitImportQuery">Filter</button>
+							</div>
+						<nav id = "importedFilesNav">
+							<ul id="importedFilesList">
+
+							</ul>
+						</nav>
+					</div>
 				</div>
 			</div>
 			<div title="Higher number = faster search; more computer resources" style="display: none;">Max threads:

--- a/favoritesSearch.html
+++ b/favoritesSearch.html
@@ -24,7 +24,7 @@
 				<a href="tutorial.html" target="_blank">About</a>
 			</form>
 			<input type="checkbox" id="advancedMode">
-			<label for="advancedMode" style="white-space:pre-wrap;">Advanced Mode (loads API data for images, allowing you to sort and filter them)</label>
+			<label for="advancedMode" style="white-space:pre-wrap;">Advanced Mode (loads additional data for posts like width, height, upload date, etc.)</label>
 			<br>
 			<input type="checkbox" id="expandUI">
 			<label for="expandUI">Expand UI</label>
@@ -88,7 +88,7 @@
 							</ul>
 						</nav>
 					</div>
-					<fieldset id="settings" class="subUIelement" style="display: none;">
+					<fieldset id="settings" class="subUIelement">
 						<h3 style="text-align: center">Advanced Mode</h3>
 						<br>
 						<div>

--- a/favoritesSearch.html
+++ b/favoritesSearch.html
@@ -47,24 +47,6 @@
 							</ul>
 						</nav>
 					</div>
-					<div class="subUIelement" id="customRequestContainer">
-						<h3 style="text-align: center">Custom Requests</h3>
-						<form autocomplete="on" action="javascript:void(0);">
-							<div>
-								<input type="text" id="customID" placeholder="User Id" autocomplete="on" size="15">
-								<input type="number" id="customPage" placeholder="Page" autocomplete="on" style="width:5em">
-								<button type="button" id="requestCustomPage">Request Page</button>
-							</div>
-							<div class="awesomplete" id="customQueryDiv"><input id="customQuery" placeholder="Enter tags to filter custom posts" name="tags" size="23" type="text" value="" autocomplete="off" aria-autocomplete="list"><ul hidden=""></ul><span class="visually-hidden" role="status" aria-live="assertive" aria-relevant="additions"></span></div>
-							<button type="button" id= "submitCustomQuery">Filter Custom Posts</button>
-						</form>
-						
-						<nav class = "requestNav">
-							<ul class="requestList" id="customRequestList">
-
-							</ul>
-						</nav>
-					</div>
 					<fieldset id="settings" class="subUIelement">
 						<h3 style="text-align: center">Advanced Mode</h3>
 						<br>
@@ -110,6 +92,24 @@
 						</div>
 						<br>
 					</fieldset>
+					<div class="subUIelement" id="customRequestContainer">
+						<h3 style="text-align: center">Custom Requests</h3>
+						<form autocomplete="on" action="javascript:void(0);">
+							<div>
+								<input type="text" id="customID" placeholder="User Id" autocomplete="on" size="15">
+								<input type="number" id="customPage" placeholder="Page" autocomplete="on" style="width:5em">
+								<button type="button" id="requestCustomPage">Request Page</button>
+							</div>
+							<div class="awesomplete" id="customQueryDiv"><input id="customQuery" placeholder="Enter tags to filter custom posts" name="tags" size="23" type="text" value="" autocomplete="off" aria-autocomplete="list"><ul hidden=""></ul><span class="visually-hidden" role="status" aria-live="assertive" aria-relevant="additions"></span></div>
+							<button type="button" id= "submitCustomQuery">Filter Custom Posts</button>
+						</form>
+						
+						<nav class = "requestNav">
+							<ul class="requestList" id="customRequestList">
+
+							</ul>
+						</nav>
+					</div>
 					<div class="subUIelement" id="fileManager">
 						<h3 style="text-align: center">Import/Export Favorites</h3>
 							<div>

--- a/loading.js
+++ b/loading.js
@@ -521,6 +521,53 @@ var displayData = (thumb, statistic) => {
 	}
 }
 
+// TODO! Finish this function
+/**
+ * Extracts score and rating from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
+ * @param {HTMLScriptElement} scriptTag 
+ */
+function extractScoreAndRatingFromScriptTag(scriptTag) {
+	const scriptTagText = scriptTag.innerText;
+	const openingBraceLocation = scriptTagText.indexOf("{");
+	const closingBraceLocation = scriptTagText.indexOf("}");
+	// Extract relevant portion and remove unneccesary code
+	const relevantDataText = scriptTagText.substring(openingBraceLocation, closingBraceLocation + 1).replace(".split(/ /g)","");
+	// now, replace all single quotes with double quotes to prepare for JSON parsing
+	const JSONText = `${relevantDataText.replaceAll(`'`,`"`)}`;
+	const dataObject = JSON.parse(JSONText);
+	const rating = dataObject.rating.toLowerCase()[0];
+	const score = dataObject.score;
+	const data = {rating:rating, score:score};
+	return data;
+}
+
+// TODO! Might be able to use nextSiblingElement function to get script tags after thumb elements
+// TODO! Remove this function if no longer needed
+/**
+ * Extracts score and rating data from script tags next to thumb elements in pages from site
+ * @param {Document} doc 
+ * @returns {Object[]}
+ */
+function extractPagePostMetadata(doc) {
+	let outputDataArray = [];
+	const scriptTags = Array.from(doc.getElementsByTagName("script"));
+	// 7th script tag will always contain data for first post (unless no posts on page)
+	const startIndex = 7;
+	for (let i = startIndex; i < scriptTags.length; i++) {
+		console.log(i);
+		const scriptTag = scriptTags[i];
+		const scriptTagText = scriptTag.innerText;
+		// make sure this script tag contains an indexing of array "posts" to ensure it has data needed
+		if (!scriptTagText.includes("posts[")) {
+			console.log(scriptTagText);
+			continue;
+		}
+		const data = extractScoreAndRatingFromScriptTag(scriptTag);
+		outputDataArray.push(data);
+	}
+	return outputDataArray;
+}
+
 function extractPagePostData(doc) {
 	let outputData = [];
 	const thumbs = doc.getElementsByClassName("thumb");

--- a/loading.js
+++ b/loading.js
@@ -578,7 +578,7 @@ async function loadContent(doc, commands, advanced, abortSignal)
 	// get just score/rating data if not in advanced mode from neighboring script elements
 	for (const newThumb of newThumbs) {
 		const scriptTag = newThumb.nextElementSibling;
-		const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
+		const metadata = extractScoreAndRatingAndIDFromScriptTag(scriptTag);
 		newThumb.metadata = metadata;
 	}
 

--- a/loading.js
+++ b/loading.js
@@ -569,6 +569,13 @@ async function loadContent(doc, commands, advanced, abortSignal)
 	let newThumbs = getThumbs(doc, commands)
 	newThumbs = Array.from(newThumbs)
 
+	// get just score/rating data if not in advanced mode from neighboring script elements
+	for (const newThumb of newThumbs) {
+		const scriptTag = newThumb.nextElementSibling;
+		const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
+		newThumb.metadata = metadata;
+	}
+	
 	// get API data if in advanced mode
 	if (advanced) {
 		const promises = newThumbs.map( async (thumb) => {
@@ -588,15 +595,6 @@ async function loadContent(doc, commands, advanced, abortSignal)
 				console.error(result.e.message)
 			}
 		});
-	}
-	// get just score/rating data if not in advanced mode from neighboring script elements
-	else {
-		for (const newThumb of newThumbs) {
-			const scriptTag = newThumb.nextElementSibling;
-			const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
-			newThumb.metadata = metadata;
-		}
-		
 	}
 	
 	// Add new thumbs to document

--- a/loading.js
+++ b/loading.js
@@ -520,6 +520,9 @@ var displayData = (thumb, statistic) => {
 		thumb.appendChild(document.createElement('br'))
 	} else {
 		currentLabel.replaceWith(dataLabel)
+		// make sure to unhide break
+		thumb.getElementsByTagName("br")[0].style.display = '';
+
 	}
 }
 

--- a/loading.js
+++ b/loading.js
@@ -523,23 +523,29 @@ var displayData = (thumb, statistic) => {
 	}
 }
 
-// TODO! Also extract post ID
 /**
- * Extracts score and rating from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
+ * Extracts score, rating, and ID from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
  * @param {HTMLScriptElement} scriptTag 
  */
-function extractScoreAndRatingFromScriptTag(scriptTag) {
-	const scriptTagText = scriptTag.innerText;
+function extractScoreAndRatingAndIDFromScriptTag(scriptTag) {
+	// exclude beginning comment from script tag
+	const scriptTagText = scriptTag.innerText.substring(15);
+
 	const openingBraceLocation = scriptTagText.indexOf("{");
 	const closingBraceLocation = scriptTagText.indexOf("}");
+	// Use these indices to extract post ID from 'posts[4378943]'
+	const openingArrayIndex = scriptTagText.indexOf("[");
+	const closingArrayIndex = scriptTagText.indexOf("]");
 	// Extract relevant portion and remove unneccesary code
 	const relevantDataText = scriptTagText.substring(openingBraceLocation, closingBraceLocation + 1).replace(".split(/ /g)","");
+	// Also extract post ID
+	const postID = parseInt(scriptTagText.substring(openingArrayIndex + 1, closingArrayIndex))
 	// now, replace all single quotes with double quotes to prepare for JSON parsing
 	const JSONText = `${relevantDataText.replaceAll(`'`,`"`)}`;
 	const dataObject = JSON.parse(JSONText);
 	const rating = dataObject.rating.toLowerCase()[0];
 	const score = dataObject.score;
-	const data = {rating:rating, score:score};
+	const data = {rating:rating, score:score,id:postID};
 	return data;
 }
 
@@ -575,7 +581,7 @@ async function loadContent(doc, commands, advanced, abortSignal)
 		const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
 		newThumb.metadata = metadata;
 	}
-	
+
 	// get API data if in advanced mode
 	if (advanced) {
 		const promises = newThumbs.map( async (thumb) => {

--- a/loading.js
+++ b/loading.js
@@ -527,25 +527,20 @@ var displayData = (thumb, statistic) => {
  * Extracts score, rating, and ID from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
  * @param {HTMLScriptElement} scriptTag 
  */
-function extractScoreAndRatingAndIDFromScriptTag(scriptTag) {
+function extractScoreAndRatingFromScriptTag(scriptTag) {
 	// exclude beginning comment from script tag
 	const scriptTagText = scriptTag.innerText.substring(15);
 
 	const openingBraceLocation = scriptTagText.indexOf("{");
 	const closingBraceLocation = scriptTagText.indexOf("}");
-	// Use these indices to extract post ID from 'posts[4378943]'
-	const openingArrayIndex = scriptTagText.indexOf("[");
-	const closingArrayIndex = scriptTagText.indexOf("]");
 	// Extract relevant portion and remove unneccesary code
 	const relevantDataText = scriptTagText.substring(openingBraceLocation, closingBraceLocation + 1).replace(".split(/ /g)","");
-	// Also extract post ID
-	const postID = parseInt(scriptTagText.substring(openingArrayIndex + 1, closingArrayIndex))
 	// now, replace all single quotes with double quotes to prepare for JSON parsing
 	const JSONText = `${relevantDataText.replaceAll(`'`,`"`)}`;
 	const dataObject = JSON.parse(JSONText);
 	const rating = dataObject.rating.toLowerCase()[0];
 	const score = dataObject.score;
-	const data = {rating:rating, score:score,id:postID};
+	const data = {rating:rating, score:score};
 	return data;
 }
 
@@ -578,7 +573,7 @@ async function loadContent(doc, commands, advanced, abortSignal)
 	// get just score/rating data if not in advanced mode from neighboring script elements
 	for (const newThumb of newThumbs) {
 		const scriptTag = newThumb.nextElementSibling;
-		const metadata = extractScoreAndRatingAndIDFromScriptTag(scriptTag);
+		const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
 		newThumb.metadata = metadata;
 	}
 

--- a/loading.js
+++ b/loading.js
@@ -630,7 +630,6 @@ async function loadContent(doc, commands, advanced, abortSignal)
 		// Ensure the link opens in a new tab
 		as[0].target = "_blank";
 
-		// TODO! Uncomment this line
 		displayData(thumb, statDisplayed.value)
 
 		// Add the link to show the original image

--- a/loading.js
+++ b/loading.js
@@ -526,7 +526,6 @@ var displayData = (thumb, statistic) => {
 	}
 }
 
-// TODO! Finish this function
 /**
  * Extracts score and rating from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
  * @param {HTMLScriptElement} scriptTag 
@@ -544,33 +543,6 @@ function extractScoreAndRatingFromScriptTag(scriptTag) {
 	const score = dataObject.score;
 	const data = {rating:rating, score:score};
 	return data;
-}
-
-// TODO! Might be able to use nextSiblingElement function to get script tags after thumb elements
-// TODO! Remove this function if no longer needed
-/**
- * Extracts score and rating data from script tags next to thumb elements in pages from site
- * @param {Document} doc 
- * @returns {Object[]}
- */
-function extractPagePostMetadata(doc) {
-	let outputDataArray = [];
-	const scriptTags = Array.from(doc.getElementsByTagName("script"));
-	// 7th script tag will always contain data for first post (unless no posts on page)
-	const startIndex = 7;
-	for (let i = startIndex; i < scriptTags.length; i++) {
-		console.log(i);
-		const scriptTag = scriptTags[i];
-		const scriptTagText = scriptTag.innerText;
-		// make sure this script tag contains an indexing of array "posts" to ensure it has data needed
-		if (!scriptTagText.includes("posts[")) {
-			console.log(scriptTagText);
-			continue;
-		}
-		const data = extractScoreAndRatingFromScriptTag(scriptTag);
-		outputDataArray.push(data);
-	}
-	return outputDataArray;
 }
 
 function extractPagePostData(doc) {

--- a/loading.js
+++ b/loading.js
@@ -474,10 +474,12 @@ var displayData = (thumb, statistic) => {
 		dataLabel.textContent = `API data unavailable`
 	} else{
 		if (statistic == "none") {
-			// remove current label's text if it exists
+			// hide current label and break
 			if (currentLabel != 'none') {
-				currentLabel.textContent = ''
-				return
+				currentLabel.textContent = '';
+				currentLabel.style.display = 'none';
+				thumb.getElementsByTagName("br")[0].style.display = 'none';
+				return;
 			}
 		}
 		let labelText = ''
@@ -612,9 +614,18 @@ async function loadContent(doc, commands, advanced, abortSignal)
 			}
 		});
 	}
+	// get just score/rating data if not in advanced mode from neighboring script elements
+	else {
+		for (const newThumb of newThumbs) {
+			const scriptTag = newThumb.nextElementSibling;
+			const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
+			newThumb.metadata = metadata;
+		}
+		
+	}
 	
 	// Add new thumbs to document
-	for (var i = 0; i < newThumbs.length; i++)
+	for (let i = 0; i < newThumbs.length; i++)
 	{
 		var thumb = newThumbs[i];
 		thumb.id = getIDfromThumb(thumb)
@@ -644,10 +655,8 @@ async function loadContent(doc, commands, advanced, abortSignal)
 		// Ensure the link opens in a new tab
 		as[0].target = "_blank";
 
-		// display stats if advanced mode enabled
-		if (advanced) {
-			displayData(thumb, statDisplayed.value)
-		}
+		// TODO! Uncomment this line
+		displayData(thumb, statDisplayed.value)
 
 		// Add the link to show the original image
 		addShowOriginal(thumb, img, as)

--- a/loading.js
+++ b/loading.js
@@ -574,6 +574,8 @@ async function loadContent(doc, commands, advanced, abortSignal)
 	for (const newThumb of newThumbs) {
 		const scriptTag = newThumb.nextElementSibling;
 		const metadata = extractScoreAndRatingFromScriptTag(scriptTag);
+		const postID = getIDfromThumb(newThumb);
+		metadata.id = postID;
 		newThumb.metadata = metadata;
 	}
 

--- a/loading.js
+++ b/loading.js
@@ -469,50 +469,47 @@ function reflect(promise){
 var displayData = (thumb, statistic) => {
 	const dataLabel = document.createElement('label')
 	const currentLabel = thumb.getElementsByTagName('label')[0]
-
-	if (thumb.metadata == undefined) {
-		dataLabel.textContent = `API data unavailable`
-	} else{
-		if (statistic == "none") {
-			// hide current label and break
-			if (currentLabel != 'none') {
-				currentLabel.textContent = '';
-				currentLabel.style.display = 'none';
-				thumb.getElementsByTagName("br")[0].style.display = 'none';
-				return;
-			}
+	if (statistic == "none") {
+		// hide current label and break
+		if (currentLabel != 'none') {
+			currentLabel.textContent = '';
+			currentLabel.style.display = 'none';
+			thumb.getElementsByTagName("br")[0].style.display = 'none';
+			return;
 		}
-		let labelText = ''
-		const metadata = thumb.metadata
-		switch (statistic) {
-			case 'score':
-				labelText = `Score: ${metadata.score}`
-				break
-			case 'id':
-				labelText = `Post ID: ${metadata.id}`
-				break
-			case 'rating':
-				labelText = `Rating: ${metadata.rating}`
-				break
-			case 'height':
-				labelText = `Height: ${metadata.height}`
-				break
-			case 'width':
-				labelText = `Width: ${metadata.width}`
-				break
-			case 'date':
-				// convert UNIX seconds time to date
-				labelText = `Date: ${metadata.date}`
-				break
-			case 'lastUpdate':
-				labelText = `Last Updated: ${new Date(metadata.lastUpdate * 1000)}`
-				break
-			case 'deleted':
-				labelText = `Deleted: ${metadata.deleted}`
-				break
-		}
-		dataLabel.textContent = labelText
 	}
+	let labelText = ''
+	const metadata = thumb.metadata
+	switch (statistic) {
+		case 'score':
+			labelText = `Score: ${metadata.score}`
+			break
+		case 'id':
+			labelText = `Post ID: ${metadata.id}`
+			break
+		case 'rating':
+			labelText = `Rating: ${metadata.rating}`
+			break
+		case 'height':
+			labelText = `Height: ${metadata.height}`
+			break
+		case 'width':
+			labelText = `Width: ${metadata.width}`
+			break
+		case 'date':
+			// convert UNIX seconds time to date
+			labelText = `Date: ${metadata.date}`
+			break
+		case 'lastUpdate':
+			labelText = `Last Updated: ${new Date(metadata.lastUpdate * 1000)}`
+			break
+		case 'deleted':
+			labelText = `Deleted: ${metadata.deleted}`
+			break
+	}
+	dataLabel.textContent = labelText
+
+
 	//label don't exist
 	if (currentLabel == null) {
 		// display info
@@ -526,6 +523,7 @@ var displayData = (thumb, statistic) => {
 	}
 }
 
+// TODO! Also extract post ID
 /**
  * Extracts score and rating from a script tag next to its sibling thumb element in page from site and returns object like {rating:"e", score:12}
  * @param {HTMLScriptElement} scriptTag 
@@ -577,7 +575,9 @@ async function loadContent(doc, commands, advanced, abortSignal)
 			const imageID = getIDfromThumb(thumb)
 			const imageInfo = await getImageInfo(imageID, abortSignal)
 			if (imageInfo == null) {
-				throw new Error(`Could not get API data for image ${imageID}`)
+				console.error(`Could not get API data for image ${imageID}`);
+				// return so we don't overwrite rating/score data with null metadata
+				return
 			}
 			thumb.metadata = imageInfo
 		})

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,4 +1,3 @@
-<!--TODO! Update tutorial to explain why score/rating can be seen without advanced mode-->
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style>body {
    color: black;
 }
@@ -78,11 +77,11 @@
 <p>Custom requests let you get posts from a specific page from a specific user. Simply enter the necessary information, then hit the "Request Page" button.</p>
 <p>You can also filter custom posts just like imported posts. However, the custom post filtering ONLY applies to custom posts.</p>
 <h1 id="advanced-mode">Advanced Mode</h1>
-<p>When the advanced mode checkbox is checked, advanced mode will be enabled. This means that when you hit the submit button, API data for each post will also be requested. </p>
-<p>Statistics like rating, score, upload date, etc will be available, which will allow you to use features in the advanced mode user interface.</p>
-<p>The checkboxes titled "Explicit", "Questionable", and "Safe" determine what posts can be displayed based on the rating. Note that these checkboxes don't automatically filter out requested images, so you may have to check and uncheck the box after all images are loaded.</p>
-<p>The dropdown by the text that says "Sort By" allows you to sort images by score, post ID, height, width, or last update date. Additionally, the checkbox next to it allows you to select whether you want to sort in ascending or descending order.</p>
-<p>Finally, there is a dropdown that allows you to select what statistic to display. The statistic, such as score or post ID, will be displayed beneath the image in black text.</p>
+<p>Usually, the only extra data that posts contain are the post ID, the score, and the rating. However, when the advanced mode checkbox is checked, advanced mode will be enabled.</p>
+<p>This means that when you hit the submit button, API data for each post will also be requested. The API data includes the image width, height, upload date, last update date, and deletion status.</p>
+<p>The checkboxes titled "Explicit", "Questionable", and "Safe" determine what posts can be displayed based on the rating. You can uncheck a box to exclude posts with that rating. Then, hit the filter button to apply your preferences.</p>
+<p>The dropdown by the text that says "Sort By" allows you to sort images by score, post ID, height, width, or last update date. Additionally, the checkbox next to it allows you to select whether you want to sort in ascending or descending order. Then, you can hit the sort button to apply the sort.</p>
+<p>Finally, there is a dropdown that allows you to select what statistic to display. The statistic, such as score or post ID, will be displayed beneath the image in black text. If you don't use advanced mode to request all the data for a post, then not all statistics will be available to display.</p>
 <h1 id="additional-info">Additional Info</h1>
 <p>API requests usually fail if the post was uploaded to Rule34 recently. The post's data likely hasn't been put into the API Database yet. </p><p></p>
 <p>

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,4 +1,4 @@
-
+<!--TODO! Update tutorial to explain why score/rating can be seen without advanced mode-->
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style>body {
    color: black;
 }

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,5 +1,4 @@
 
-<!-- TODO! Explain importing/exporting and custom requests -->
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style>body {
    color: black;
 }

--- a/ui.js
+++ b/ui.js
@@ -91,15 +91,6 @@ expandUI.addEventListener('change', evt => {
 	}
 })
 
-advancedMode.addEventListener('change', evt => {
-	if (advancedMode.checked) {
-		//back to normal
-		settings.style = ''
-	} else {
-		settings.style.display = 'none'
-	}
-})
-
 // by UndertowTruck
 // changes stat displayed based on dropdown change
 statDisplayed.addEventListener('change', evt => {


### PR DESCRIPTION
I noticed that in the favorites pages, there's some script tags that contain post data with the score and rating of each post. This means no API call needed to get this information, so I made it so that score/rating data will automatically come with requested posts without being in advanced mode and without any API calls